### PR TITLE
use more compatible mime type for jpeg images

### DIFF
--- a/websock.c
+++ b/websock.c
@@ -283,8 +283,8 @@ int cWebSock::serveFile(lws* wsi, const char* path)
    if (!isEmpty(suffix))
    {
       if      (strcmp(suffix, "png") == 0)   mime = "image/png";
-      else if (strcmp(suffix, "jpg") == 0)   mime = "image/jpg";
-      else if (strcmp(suffix, "jpeg") == 0)  mime = "image/jpg";
+      else if (strcmp(suffix, "jpg") == 0)   mime = "image/jpeg";
+      else if (strcmp(suffix, "jpeg") == 0)  mime = "image/jpeg";
       else if (strcmp(suffix, "gif") == 0)   mime = "image/gif";
       else if (strcmp(suffix, "svg") == 0)   mime = "image/svg+xml";
       else if (strcmp(suffix, "html") == 0)  mime = "text/html";


### PR DESCRIPTION
Some mime type libraries have difficulties to recognize "image/jpg" (for example python's mimetype library needs the non-strict option to recognize it properly). According to https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#Images_types "image/jpeg" is more compatible.