### PR TITLE
fix in-tree build

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -20,7 +20,7 @@ else
   CC = g++
 endif
 
-doCompile = $(CC) -c $(CFLAGS) $(DEFINES)
+doCompile = $(CC) -c $(CFLAGS) $(DEFINES) $(INCLUDES)
 doLink    = $(CC) $(LFLAGS)
 doLib     = ar -rs
 

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ hlib:
 ### Implicit rules:
 
 %.o: %.c
-	$(doCompile) $(INCLUDES) -o $@ $<
+	$(doCompile) -o $@ $<
 #	$(CXX) $(CXXFLAGS) -c $(DEFINES) $(INCLUDES) -o $@ $<
 
 ### Dependencies:


### PR DESCRIPTION
add missing 'INCLUDES' to Make.config, because vdr headers weren't found in lib/Makefile